### PR TITLE
Allow StatsBase 0.32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ Plots = "1.0"
 ProgressMeter = "1.2"
 Requires = "1.0"
 SlidingDistancesBase = "0.1.3"
-StatsBase = "0.33"
+StatsBase = "0.32, 0.33"
 UnsafeArrays = "1.0"
 julia = "1"
 


### PR DESCRIPTION
I think this should be OK since the only breaking change in StatsBase 0.32 -> 0.33 was https://github.com/JuliaStats/StatsBase.jl/pull/567.

Widening compat would be useful since Diagonalizations.jl does not yet support 0.33 and I was hoping to use the two together. (another route to success: https://github.com/Marco-Congedo/Diagonalizations.jl/pull/56)