### PR TITLE
GDTW fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,8 +35,10 @@ UnPack = "0.1, 1"
 julia = "1"
 
 [extras]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 MatrixProfile = "24e37439-14ec-4097-bda3-6a65822e2305"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
 [targets]
-test = ["MatrixProfile", "LightGraphs"]
+test = ["MatrixProfile", "LightGraphs", "QuadGK", "ForwardDiff"]

--- a/examples/gdtw.jl
+++ b/examples/gdtw.jl
@@ -12,7 +12,7 @@ ylabel!("Amplitude")
 title!("Original signals")
 
 
-cost, ϕ = gdtw(x, y; N = 200)
+cost, ϕ = gdtw(x, y)
 gdtw_plot = plot(t, x ∘ ϕ, label="x∘ϕ(t)")
 plot!(t, y, label="y(t)")
 xlabel!("Time")

--- a/src/gdtw.jl
+++ b/src/gdtw.jl
@@ -43,7 +43,15 @@ function inital_bounds!(l, u, t, smin, smax)
     # which can lead to very wrong results.
     smin = .99*smin
     smax = 1.01*smax
+
     @inbounds for i in eachindex(t, l, u)
+        # You must be able to get to `warp[i]` in time `t[i]`, so
+        #   `smax >= warp[i] / t[i] >= smin`
+        # This gives a lower and upper bound on `warp[i]`, i.e., on `τ[:, i]`.
+        # You must be able to get to `1` from `warp[i]` in time `1-t[i]`, so
+        #   `smin <= (1-warp[i])/(1-t[i]) <= smax`
+        # this gives another lower and upper bound.
+        # The resulting bounds:
         l[i] = max(smin * t[i], 1 - smax * (1 - t[i]))
         u[i] = min(smax * t[i], 1 - smin * (1 - t[i]))
     end

--- a/src/gdtw.jl
+++ b/src/gdtw.jl
@@ -57,7 +57,7 @@ function update_τ!(τ, t, M, l, u)
 end
 
 """
-    prepare_gdtw(
+    gdtw(
         x,
         y,
         ::Type{T}  = Float64;
@@ -264,7 +264,7 @@ struct LinearInterpolation{Tx,Tt} <: Function
     x::Tx
     t::Tt
     function LinearInterpolation(x::Tx, ts::Ts) where {Tx,Ts}
-        @assert issorted(ts)
+        issorted(ts) || throw(ArgumentError("Time parameter `ts` must be sorted in increasing order."))
         T = eltype(Tx)
         t = (ts .- T(first(ts))) ./ T( last(ts) - first(ts))
         Tt = typeof(t)

--- a/src/gdtw.jl
+++ b/src/gdtw.jl
@@ -36,8 +36,13 @@ function refine!(l_current, u_current, l_prev, u_prev, l₀, u₀, warp; η)
     return nothing
 end
 
-# inital choices of `l` and `u`, as given in Eq (7) of DB19
+# inital choices of `l` and `u`, modified from Eq (7) of DB19
 function inital_bounds!(l, u, t, smin, smax)
+    # We need to loosen the bounds to account for floating point error
+    # Otherwise these bounds can be too tight and disallow valid moves
+    # which can lead to very wrong results.
+    smin = .99*smin
+    smax = 1.01*smax
     @inbounds for i in eachindex(t, l, u)
         l[i] = max(smin * t[i], 1 - smax * (1 - t[i]))
         u[i] = min(smax * t[i], 1 - smin * (1 - t[i]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test, Statistics, LinearAlgebra
 using DynamicAxisWarping, SlidingDistancesBase
 using Distances, Plots
+using ForwardDiff, QuadGK
 
 @testset "DynamicAxisWarping" begin
     @info "Testing DynamicAxisWarping"

--- a/test/test_gdtw.jl
+++ b/test/test_gdtw.jl
@@ -51,7 +51,7 @@ end
     ts = range(0, stop=π/12, length=128)
     x = LinearInterpolation(sin.(ts))
     y = LinearInterpolation(sin.(1.1 .* ts))
-
+    metric = (x,y) -> norm(x-y)
     λinst = .1
     λcum = .1
     # We need high `N` and `M` to have low discretization error

--- a/test/test_gdtw.jl
+++ b/test/test_gdtw.jl
@@ -45,3 +45,18 @@ end
     t = range(0, stop = 1, length=20)
     @test norm(x.(t) - y.(t)) >= norm( x.(ϕ.(t)) - y.(t) )
 end
+
+@testset "GDTW: Test objective function" begin
+    # short time span to make it easy
+    ts = range(0, stop=π/12, length=128)
+    x = LinearInterpolation(sin.(ts))
+    y = LinearInterpolation(sin.(1.1 .* ts))
+
+    λinst = .1
+    λcum = .1
+    # We need high `N` and `M` to have low discretization error
+    cost, ϕ = gdtw(x, y; N = 400, M = 300, λinst=λinst, λcum=λcum)
+    ϕ′ = x -> ForwardDiff.derivative(ϕ, x)
+    res = quadgk(t -> metric(x(ϕ(t)),  y(t)) + λinst*(ϕ′(t)-1)^2 + λcum*(ϕ(t) - t)^2, 0, 1 )[1]
+    @test res ≈ cost rtol=1e-2
+end


### PR DESCRIPTION
I found three issues with my GDTW code:

1. in `Rinst`, we should compare the slope to 1, not zero. This comes from a typo in the paper (see eq. 3 vs 6)
2. I completely missed the prefactor in the Riemann sum which makes the result off by a factor of `N` (for `t = range(0,stop=1, length=N)`). To be fair, so did the paper in their description of the dynamic programming algo (see the node and edge costs on p. 9 vs the formula in eq 6)
3. The inital bounds (l₀ and u₀) are chosen according to some criteria which I documented in a comment (I assume this was the paper's reasoning although it wasn't written explicitly). These bounds are chosen to restrict the search range needed for finding the optimal path, and should help performance while not ruling out any valid paths. However, roundoff can cause them to disallow valid paths, which can cause mysterious bugs (i.e. change `N` by 1 and the answer changes by 4 orders of magnitude). Here we relax these bounds slightly to ensure they really don't rule out valid paths while still helping the perf (i.e. you don't need as high `M` to do well).

I added a test to check that the value we return matches well to what it actually should be. Unfortunately the discretization error does not decay as quickly as I'd like and you need to take a slowly varying curve and large `M` and `N` to get it to match to 1e-2. (This test fails stupendously on master!).

I actually found these while working on adding a symmetric version of the gdtw distance. I think that's pretty much working locally but I thought I'd put this up first and get back to that early next week.