### PR TITLE
Fix DBA for multidimensional sequences

### DIFF
--- a/src/dba.jl
+++ b/src/dba.jl
@@ -139,12 +139,12 @@ function dba_iteration!(
         # store stats for barycentric average
         for j = 1:length(i2)
             counts[i1[j]] += 1
-            newavg[!,i1[j]] += seq[i2[j]]
+            newavg[!,i1[j]] += seq[!,i2[j]]
         end
     end
 
     # compute average and return total cost
-    for i in eachindex(newavg)
+    for i in eachindex(counts)
         newavg[!,i] = newavg[!,i] / counts[i]
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,11 +388,20 @@ using ForwardDiff, QuadGK
     end
 
     @testset "DBA" begin
+        @info "Testing DBA"
+        # one-dimensional sequences
         x = [1.0, 2.0, 2.0, 3.0, 3.0, 4.0]
         y = [1.0, 3.0, 4.0]
         z = [1.0, 2.0, 2.0, 4.0]
-        avg, _ = dba([x, y, z], DTW(5), init_center = z)
+        avg, _ = dba([x, y, z], DTW(5), init_center = z, show_progress=false)
         @test avg == [1.0, 1.75, 2.75, 4.0]
+
+        # multi-dimensional sequences
+        x = [1.0 2.0 2.0 3.0 3.0 4.0; 1.0 2.0 2.0 3.0 3.0 4.0; 1.0 2.0 2.0 3.0 3.0 4.0]
+        y = [1.0 3.0 4.0; 1.0 3.0 4.0; 1.0 3.0 4.0]
+        z = [1.0 2.0 2.0 4.0; 1.0 2.0 2.0 4.0; 1.0 2.0 2.0 4.0]
+        avg, _ = dba([x, y, z], DTW(5), init_center = z, show_progress=false)
+        @test avg == [1.0 1.75 2.75 4.0; 1.0 1.75 2.75 4.0; 1.0 1.75 2.75 4.0]
     end
 
 


### PR DESCRIPTION
The `dba()` function wasn't working for multidimensional sequences due to a few indexing issues. This PR fixes the indexing and adds a multidimensional unit test for `dba()`. It also adds an info printout when testing `dba()` and suppresses the progress information from running the function.