### PR TITLE
Improve user interface with default distance as keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Any distance implementing the [Distances.jl](https://github.com/JuliaStats/Dista
 
 ```julia
 using DynamicAxisWarping, Distances, Plots
-cost, i1, i2 = dtw(a,b, [dist=SqEuclidean()]; transportcost = 1)
-cost, i1, i2 = fastdtw(a,b, dist, radius) # note https://arxiv.org/abs/2003.11246
-cost = dtw_cost(a, b, dist, radius) # Optimized method that only returns cost. Supports early stopping, see docstring. Can be made completely allocation free.
+cost, i1, i2 = dtw(a, b, [dist=SqEuclidean()]; transportcost = 1)
+cost, i1, i2 = fastdtw(a, b, radius; dist = SqEuclidean()) # note https://arxiv.org/abs/2003.11246
+cost = dtw_cost(a, b, radius; dist = SqEuclidean()) # Optimized method that only returns cost. Supports early stopping, see docstring. Can be made completely allocation free.
 
 # dtw supports arbitrary upper and lower bound vectors constraining the warping path.
 imin,imax = radiuslimits(5,20,20), plot([imin imax])

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Any distance implementing the [Distances.jl](https://github.com/JuliaStats/Dista
 
 ```julia
 using DynamicAxisWarping, Distances, Plots
-cost, i1, i2 = dtw(a, b, [dist=SqEuclidean()]; transportcost = 1)
-cost, i1, i2 = fastdtw(a, b, radius; dist = SqEuclidean()) # note https://arxiv.org/abs/2003.11246
-cost = dtw_cost(a, b, radius; dist = SqEuclidean()) # Optimized method that only returns cost. Supports early stopping, see docstring. Can be made completely allocation free.
+cost, i1, i2 = dtw(a,b, [dist=SqEuclidean()]; transportcost = 1)
+cost, i1, i2 = fastdtw(a,b, dist, radius) # note https://arxiv.org/abs/2003.11246
+cost = dtw_cost(a, b, dist, radius) # Optimized method that only returns cost. Supports early stopping, see docstring. Can be made completely allocation free.
 
 # dtw supports arbitrary upper and lower bound vectors constraining the warping path.
 imin,imax = radiuslimits(5,20,20), plot([imin imax])

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -156,7 +156,7 @@ end
 
 
 """
-    dtw_cost(a::AbstractArray, b::AbstractArray, r::Int; dist::Distances.SemiMetric = SqEuclidean(), best_so_far = Inf, cumulative_bound = Zeros(length(a)))
+   dtw_cost(a::AbstractArray, b::AbstractArray, dist::Distances.SemiMetric, r::Int; best_so_far = Inf, cumulative_bound = Zeros(length(a))) 
 
 Perform dynamic time warping to measure the distance between two sequences.
 

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -156,13 +156,14 @@ end
 
 
 """
-    dtw_cost(a::AbstractArray, b::AbstractArray, dist::Distances.SemiMetric, r::Int; best_so_far = Inf, cumulative_bound = Zeros(length(a)))
+    dtw_cost(a::AbstractArray, b::AbstractArray, r::Int; dist::Distances.SemiMetric = SqEuclidean(), best_so_far = Inf, cumulative_bound = Zeros(length(a)))
 
 Perform dynamic time warping to measure the distance between two sequences.
 
 Calculate the DTW cost between `a` and `b` with maximum warping radius `r`. You may provide values of `best_so_far` and `cumulative_bound` in order to enable early stopping.
 
 # Keyword arguments:
+- `dist`: The distance semi-metric to use (default: `SqEuclidean()`)
 - `best_so_far`: The best cost value obtained so far (optional)
 - `cumulative_bound`: A vector the same length as a and b (optional)
 - `s1`: Optional storage vector of length 2r+1, can be used to save allocations.
@@ -237,6 +238,9 @@ function dtw_cost(
 end
 
 
+# Convenience method with default SqEuclidean() distance
+dtw_cost(a::AbstractArray, b::AbstractArray, r::Int; kwargs...) =
+    dtw_cost(a, b, SqEuclidean(), r; kwargs...)
 
 
 @inbounds function soft_dtw_cost_matrix(seq1::AbstractArray, seq2::AbstractArray, dist::SemiMetric = SqEuclidean(); γ = 1,

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -156,7 +156,7 @@ end
 
 
 """
-   dtw_cost(a::AbstractArray, b::AbstractArray, dist::Distances.SemiMetric, r::Int; best_so_far = Inf, cumulative_bound = Zeros(length(a))) 
+    dtw_cost(a::AbstractArray, b::AbstractArray, dist::Distances.SemiMetric, r::Int; best_so_far = Inf, cumulative_bound = Zeros(length(a)))
 
 Perform dynamic time warping to measure the distance between two sequences.
 

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -163,7 +163,6 @@ Perform dynamic time warping to measure the distance between two sequences.
 Calculate the DTW cost between `a` and `b` with maximum warping radius `r`. You may provide values of `best_so_far` and `cumulative_bound` in order to enable early stopping.
 
 # Keyword arguments:
-- `dist`: The distance semi-metric to use (default: `SqEuclidean()`)
 - `best_so_far`: The best cost value obtained so far (optional)
 - `cumulative_bound`: A vector the same length as a and b (optional)
 - `s1`: Optional storage vector of length 2r+1, can be used to save allocations.

--- a/src/fastdtw.jl
+++ b/src/fastdtw.jl
@@ -1,6 +1,6 @@
 
 """
-    cost,i1,i2 = fastdtw(seq1,seq2,dist,radius)
+    cost,i1,i2 = fastdtw(seq1,seq2,radius;dist=SqEuclidean())
 
 Perform dynamic-time warping using the FastDTW algorithm to measure the distance between two sequences. Note that regular DTW often performs better than FastDTW https://arxiv.org/abs/2003.11246
 
@@ -34,6 +34,11 @@ function fastdtw(
     idx2min, idx2max = computewindow(hirescol, hiresrow, radius)
     cost1, newcol, newrow = dtw(seq1, seq2, dist, idx2min, idx2max)
 end
+
+
+# Convenience method with default SqEuclidean() distance
+fastdtw(seq1::AbstractArray, seq2::AbstractArray, radius::Int; dist=SqEuclidean()) =
+    fastdtw(seq1, seq2, dist, radius)
 
 
 # Given a path through low-res space, generate an approximate path

--- a/src/fastdtw.jl
+++ b/src/fastdtw.jl
@@ -1,6 +1,6 @@
 
 """
-    cost,i1,i2 = fastdtw(seq1,seq2,radius;dist=SqEuclidean())
+    cost,i1,i2 = fastdtw(seq1,seq2,dist,radius)
 
 Perform dynamic-time warping using the FastDTW algorithm to measure the distance between two sequences. Note that regular DTW often performs better than FastDTW https://arxiv.org/abs/2003.11246
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -436,6 +436,12 @@ using ForwardDiff, QuadGK
         @test isapprox(cost, cost1)
         @test px == qx
         @test py == qy
+
+        # default distance
+        cost2, rx, ry = fastdtw(x, y, 15) 
+        @test isequal(cost1, cost2)
+        @test qx == rx
+        @test qy == ry
     end
 
     @testset "DBA" begin


### PR DESCRIPTION
Fix #69.

The `dtw_cost_matrix` also needs a review as it is not following the keyword argument convention of the other user-facing functions. I left it out of this PR because it is a more delicate refactor.