### PR TITLE
Make dist an optional argument of dtw

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cost = dtw_cost(a, b, dist, radius) # Optimized method that only returns cost. S
 
 # dtw supports arbitrary upper and lower bound vectors constraining the warping path.
 imin,imax = radiuslimits(5,20,20), plot([imin imax])
-dtw(a, b, dist, imin, imax) # Cost equivalent to dtw_cost(a, b, dist, 5)
+dtw(a, b, imin, imax, dist) # Cost equivalent to dtw_cost(a, b, dist, 5)
 
 # The Distances.jl interface is supported
 d = DTW(radius=5)

--- a/examples/frequency_warping.jl
+++ b/examples/frequency_warping.jl
@@ -49,7 +49,7 @@ dtwplot(.√(M1.power), .√(M2.power), dist, linecolor=:green)
 # We expect to see less time warping (straighter green line) now when it's allowed to fudge the distance a bit by shuffling mass along the frequency axis.
 # How long time does it take to compute such a distance? (on a laptop, expect about 3x improvement on desktop)
 @btime dtw($(M1.power), $(M2.power), $dist)
-@btime dtw($(M1.power), $(M2.power), $dist, radiuslimits(50,m,m)...)
+@btime dtw($(M1.power), $(M2.power), radiuslimits(50,m,m)..., $dist)
 # The size of the spectrogram
 size(M1.power)
 # The complexity is almost linear in the number of frequency bins, but quadratic in the number of time steps.

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -3,8 +3,8 @@
 #####################################
 
 """
-    cost,i1,i2 = dtw(seq1, seq2, [dist=SqEuclidean, postprocess=nothing])
-    cost,i1,i2 = dtw(seq1, seq2, dist, i2min, i2max)
+    cost,i1,i2 = dtw(seq1, seq2, [dist=SqEuclidean(), postprocess=nothing])
+    cost,i1,i2 = dtw(seq1, seq2, i2min, i2max, [dist=SqEuclidean()])
 
 Perform dynamic-time warping to measure the distance between two sequences.
 
@@ -74,9 +74,9 @@ end
 Base.@propagate_inbounds function dtw_cost_matrix(
     seq1::AbstractArray{T},
     seq2::AbstractArray{T},
-    dist::SemiMetric,
     i2min::AbstractVector{U},
-    i2max::AbstractVector{U};
+    i2max::AbstractVector{U},
+    dist::SemiMetric = SqEuclidean();
     transportcost = 1
 ) where {T,U<:Integer}
     n = lastlength(seq1) # of columns in cost matrix

--- a/src/fastdtw.jl
+++ b/src/fastdtw.jl
@@ -32,7 +32,7 @@ function fastdtw(
     # window around it, and get the DTW given that window.
     hirescol, hiresrow = expandpath(lowrescol, lowresrow, N1, N2)
     idx2min, idx2max = computewindow(hirescol, hiresrow, radius)
-    cost1, newcol, newrow = dtw(seq1, seq2, dist, idx2min, idx2max)
+    cost1, newcol, newrow = dtw(seq1, seq2, idx2min, idx2max, dist)
 end
 
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -30,7 +30,7 @@ function handleargs(seq1::AbstractArray, seq2::AbstractArray, D::AbstractMatrix,
 end
 
 function handleargs(seq1, seq2, dist, i2min, i2max; kwargs...)
-    D = dtw_cost_matrix(seq1, seq2, dist, i2min, i2max; kwargs...)
+    D = dtw_cost_matrix(seq1, seq2, i2min, i2max, dist; kwargs...)
     cost, i1, i2 = DynamicAxisWarping.trackback(D)
     seq1, seq2, D, i1, i2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,7 +185,7 @@ using ForwardDiff, QuadGK
         dist = SqEuclidean()
         a = [1, 1, 1]
         b = [1, 1, 1]
-        cost, pa, pb = dtw(a, b, dist, [1, 1, 1], [3, 3, 3])
+        cost, pa, pb = dtw(a, b, [1, 1, 1], [3, 3, 3], dist)
         @test cost == 0
         @test pa == [1, 2, 3]
         @test pb == [1, 2, 3]
@@ -194,7 +194,7 @@ using ForwardDiff, QuadGK
         # Also check that trackback prefers diagonal moves
         a = [0, 1, 1, 1]
         b = [0, 0, 1, 1]
-        cost, pa, pb = dtw(a, b, dist, [1, 1, 1, 1], [4, 4, 4, 4])
+        cost, pa, pb = dtw(a, b, [1, 1, 1, 1], [4, 4, 4, 4], dist)
         @test cost == 0
         @test pa == [1, 1, 2, 3, 4]
         @test pb == [1, 2, 3, 3, 4]
@@ -212,7 +212,7 @@ using ForwardDiff, QuadGK
         # Wide window, not touching optimal path
         rmin = [1, 1, 1, 2, 3, 4, 5, 6]
         rmax = [4, 6, 7, 8, 8, 8, 8, 8]
-        cost, pa, pb = dtw(a, b, dist, rmin, rmax)
+        cost, pa, pb = dtw(a, b, rmin, rmax, dist)
         @test cost == 0
         @test pa == best_pa
         @test pb == best_pb
@@ -220,7 +220,7 @@ using ForwardDiff, QuadGK
         # Bottom of window is optimal path
         rmin = [1, 3, 4, 7, 8, 8, 8, 8]
         rmax = [4, 6, 7, 8, 8, 8, 8, 8]
-        cost, pa, pb = dtw(a, b, dist, rmin, rmax)
+        cost, pa, pb = dtw(a, b, rmin, rmax, dist)
         @test cost == 0
         @test pa == best_pa
         @test pb == best_pb
@@ -228,7 +228,7 @@ using ForwardDiff, QuadGK
         # Top of window is optimal path
         rmin = [1, 1, 1, 2, 3, 4, 5, 6]
         rmax = [2, 3, 6, 7, 8, 8, 8, 8]
-        cost, pa, pb = dtw(a, b, dist, rmin, rmax)
+        cost, pa, pb = dtw(a, b, rmin, rmax, dist)
         @test cost == 0
         @test pa == best_pa
         @test pb == best_pb
@@ -236,7 +236,7 @@ using ForwardDiff, QuadGK
         # Top and bottom of window are optimal path
         rmin = [1, 3, 4, 7, 8, 8, 8, 8]
         rmax = [2, 3, 6, 7, 8, 8, 8, 8]
-        cost, pa, pb = dtw(a, b, dist, rmin, rmax)
+        cost, pa, pb = dtw(a, b, rmin, rmax, dist)
         @test cost == 0
         @test pa == best_pa
         @test pb == best_pb
@@ -244,7 +244,7 @@ using ForwardDiff, QuadGK
         # Now top of window cuts into optimal path
         rmin = [1, 1, 1, 2, 3, 4, 5, 6]
         rmax = [4, 4, 5, 6, 7, 8, 8, 8]
-        cost, pa, pb = dtw(a, b, dist, rmin, rmax)
+        cost, pa, pb = dtw(a, b, rmin, rmax, dist)
         @test cost == 2
         @test pa == [1, 1, 2, 3, 3, 4, 5, 6, 7, 8]
         @test pb == [1, 2, 3, 4, 5, 6, 7, 8, 8, 8]
@@ -254,7 +254,7 @@ using ForwardDiff, QuadGK
         seq2 = seq1[1:2:end]
         cost, pa, pb = dtw(seq1, seq2)
         n1, n2 = length(seq1), length(seq2)
-        cost2, qa, qb = dtw(seq1, seq2, dist, fill(1, n1), fill(n2, n1))
+        cost2, qa, qb = dtw(seq1, seq2, fill(1, n1), fill(n2, n1), dist)
         @test cost == cost2
         @test pa == qa
         @test pb == qb
@@ -304,7 +304,7 @@ using ForwardDiff, QuadGK
 
         cost, pa, pb = dtw(seq1, seq2)
         n1, n2 = length(seq1), length(seq2)
-        cost2, qa, qb = dtw(seq1, seq2, dist, fill(1, n1), fill(n2, n1))
+        cost2, qa, qb = dtw(seq1, seq2, fill(1, n1), fill(n2, n1), dist)
         @test cost == cost2
         @test pa == qa
         @test pb == qb


### PR DESCRIPTION
Similar fix to make the `dist` optional in `dtw` as it was done in #69 for `fastdtw`.

Unfortunately, this improvement cannot be implemented without breaking the API.