### PR TITLE
Fix missing range operator in pairwise comprehension

### DIFF
--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -34,7 +34,7 @@ end
 Distances.pairwise(d::PreMetric, s1::AbstractVector, s2::AbstractVector; dims=2) = evaluate.(Ref(d), s1, transpose(s2))
 
 function Distances.pairwise(d::PreMetric, s1::AbstractArray, s2::AbstractArray; dims=2)
-    [evaluate(d, s1[!,i], s2[!,j]) for i in 1:lastlength(s1), j in lastlength(s2)]
+    [evaluate(d, s1[!,i], s2[!,j]) for i in 1:lastlength(s1), j in 1:lastlength(s2)]
 end
 
 @inbounds function dtw_cost_matrix(seq1::AbstractArray{T}, seq2::AbstractArray{T}, dist::SemiMetric = SqEuclidean();

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,22 @@ using ForwardDiff, QuadGK
         @test dtwnn(a,a,SqEuclidean(),3,ZNormalizer).cost < 1e-20
     end
 
+    @testset "pairwise on multi-channel arrays" begin
+        # Regression for #72: the inner loop of `pairwise(::PreMetric, ::AbstractArray, ::AbstractArray)`
+        # iterated `j in lastlength(s2)` instead of `j in 1:lastlength(s2)`, producing a
+        # column-degenerate matrix and breaking `dtw_cost_matrix` for multi-channel inputs.
+        A = Float64[1 2 3 4; 5 6 7 8]   # 2 channels × 4 timepoints
+        B = Float64[1 2 3 4 5; 5 6 7 8 9]  # 2 channels × 5 timepoints
+        D = DynamicAxisWarping.pairwise(SqEuclidean(), A, B; dims=2)
+        @test size(D) == (4, 5)
+        @test D[1, 1] ≈ SqEuclidean()(A[:, 1], B[:, 1])
+        @test D[4, 5] ≈ SqEuclidean()(A[:, 4], B[:, 5])
+
+        # End-to-end: dtw_cost_matrix dispatches through this method when given matrices.
+        C = dtw_cost_matrix(A, B)
+        @test size(C) == (lastlength(B), lastlength(A))
+    end
+
     @testset "Basic Dynamic Time Warping" begin
         @info "Testing Basic Dynamic Time Warping"
         a = Float64[1, 1, 1, 2, 4, 6, 5, 5, 5, 4, 4, 3, 1, 1, 1]


### PR DESCRIPTION
## Summary
- `Distances.pairwise(::PreMetric, ::AbstractArray, ::AbstractArray)` in `src/dtw.jl` iterated `j in lastlength(s2)` instead of `j in 1:lastlength(s2)`, visiting a single value rather than every column. This silently broke any DTW path that goes through this method for multi-channel inputs.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] Verify `DynamicAxisWarping.pairwise(SqEuclidean(), rand(2,4), rand(2,5))` returns a 4×5 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)