### PR TITLE
Fix argument order in constrained distpath(::DTW, ...)

### DIFF
--- a/src/distance_interface.jl
+++ b/src/distance_interface.jl
@@ -89,8 +89,8 @@ Distances.evaluate(d::FastDTW, x, y) =
     fastdtw(x, y, d.dist, d.radius)[1]
 
 distpath(d::DTW, x, y) = dtw(x, y, d.dist; transportcost=d.transportcost, postprocess = d.postprocess)
-distpath(d::DTW, x, y, i2min::AbstractVector, i2max::AbstractVector; transportcost=d.transportcost) =
-    dtw(x, y, i2min, i2max, d.dist)
+distpath(d::DTW, x, y, i2min::AbstractVector, i2max::AbstractVector) =
+    dtw(x, y, d.dist, i2min, i2max; transportcost=d.transportcost)
 distpath(d::FastDTW, x, y) = fastdtw(x, y, d.dist, d.radius)
 
 (d::DTWDistance)(x,y;kwargs...) = Distances.evaluate(d,x,y;kwargs...)

--- a/src/distance_interface.jl
+++ b/src/distance_interface.jl
@@ -88,9 +88,9 @@ Distances.evaluate(d::SoftDTW, x, y) = soft_dtw_cost(x, y, d.dist, γ=d.γ, radi
 Distances.evaluate(d::FastDTW, x, y) =
     fastdtw(x, y, d.dist, d.radius)[1]
 
-distpath(d::DTW, x, y) = dtw(x, y, d.dist; transportcost=d.transportcost, postprocess = d.postprocess)
-distpath(d::DTW, x, y, i2min::AbstractVector, i2max::AbstractVector) =
-    dtw(x, y, d.dist, i2min, i2max; transportcost=d.transportcost)
+distpath(d::DTW, x, y; transportcost=d.transportcost) = dtw(x, y, d.dist; transportcost, postprocess = d.postprocess)
+distpath(d::DTW, x, y, i2min::AbstractVector, i2max::AbstractVector; transportcost=d.transportcost) =
+    dtw(x, y, d.dist, i2min, i2max; transportcost)
 distpath(d::FastDTW, x, y) = fastdtw(x, y, d.dist, d.radius)
 
 (d::DTWDistance)(x,y;kwargs...) = Distances.evaluate(d,x,y;kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,6 +190,16 @@ using ForwardDiff, QuadGK
         @test pa == [1, 2, 3]
         @test pb == [1, 2, 3]
 
+        # Regression for #73: the constrained `distpath(::DTW, x, y, i2min, i2max)`
+        # had its arguments in the wrong order and raised a MethodError on every
+        # call with bounds.
+        let a = [1, 1, 1], b = [1, 1, 1]
+            cost_p, pa_p, pb_p = DynamicAxisWarping.distpath(DTW(2), a, b, [1, 1, 1], [3, 3, 3])
+            @test cost_p == 0
+            @test pa_p == [1, 2, 3]
+            @test pb_p == [1, 2, 3]
+        end
+
         # Verify that trackback ends properly if it reaches an edge before reaching [1,1]
         # Also check that trackback prefers diagonal moves
         a = [0, 1, 1, 1]


### PR DESCRIPTION
## Summary
- `distpath(::DTW, x, y, i2min, i2max)` invoked `dtw(x, y, i2min, i2max, d.dist)`, but the constrained `dtw` signature is `dtw(seq1, seq2, dist, i2min, i2max)`. Every call with bounds raised a MethodError. Triggered whenever `dba` / `dbaclust` is run with non-empty `i2min` / `i2max`.
- Also forwarded `transportcost` to the underlying `dtw` call (previously accepted as a keyword argument but silently dropped).

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] `distpath(DTW(3), rand(10), rand(10), collect(1:10), fill(10,10))` returns `(cost, i1, i2)` without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)