### PR TITLE
Fix kwargs placement in lb_endpoints

### DIFF
--- a/src/dtwnn.jl
+++ b/src/dtwnn.jl
@@ -105,12 +105,12 @@ function lb_endpoints(dist, q, buffer, best_so_far; kwargs...)
     lb >= best_so_far && return lb
 
     x2 = buffer[!,2]
-    d = min(dist(x2, q[!,1]; kwargs...), dist(x1,q[!,2]; kwargs...), dist(x2,q[!,2]); kwargs...)
+    d = min(dist(x2, q[!,1]; kwargs...), dist(x1, q[!,2]; kwargs...), dist(x2, q[!,2]; kwargs...))
     lb += d
     lb >= best_so_far && return lb
 
     y2 = buffer[!,m-1]
-    d = min(dist(y2, q[!,m]; kwargs...), dist(y1,q[!,m-1]; kwargs...), dist(y2,q[!,m-1]); kwargs...)
+    d = min(dist(y2, q[!,m]; kwargs...), dist(y1, q[!,m-1]; kwargs...), dist(y2, q[!,m-1]; kwargs...))
     lb += d
     lb >= best_so_far && return lb
 


### PR DESCRIPTION
## Summary
- In `lb_endpoints` (src/dtwnn.jl), the third `dist(...)` call inside each `min(...)` was missing `; kwargs...`, and the trailing `; kwargs...` was being applied to `min`. When any keyword argument flows down from `dtwnn`, `min` raises a MethodError. The third distance call also silently dropped the kwargs the other two received.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] `dtwnn(q, y, dist, r; some_dist_kwarg=...)` runs without MethodError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)