### PR TITLE
Fix soft-DTW radius branch double-adding penalty and softmin

### DIFF
--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -271,9 +271,9 @@ dtw_cost(a::AbstractArray, b::AbstractArray, r::Int; kwargs...) =
             for r = 2:m
                 if abs(c-r) > radius
                     D[r, c] += 1/γ
-                    # continue
-                end    
-                D[r, c] += softmin(transportcost*D[r-1, c], D[r-1, c-1], transportcost*D[r, c-1], γ)
+                else
+                    D[r, c] += softmin(transportcost*D[r-1, c], D[r-1, c-1], transportcost*D[r, c-1], γ)
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- In `soft_dtw_cost_matrix`, when `abs(c - r) > radius` the cell received the penalty `1/γ` and *then* still had the `softmin` added to it — double-counting. The commented `# continue` in the original code confirms the intent was either-or. Replacing with an explicit `else`.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] Compare `soft_dtw_cost(a, b; γ=1, radius=2)` against a hand-computed expectation on a small case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)