### PR TITLE
Serialize unused-center reinit loop in dbaclust

### DIFF
--- a/src/dbaclust.jl
+++ b/src/dbaclust.jl
@@ -261,8 +261,11 @@ function dbaclust_single(
         # with the highest cost
         unused = setdiff(1:nclust, unique(clus_asgn))
         if !isempty(unused)
-            # reinitialize centers
-            @optional_threaded threaded for c in unused
+            # reinitialize centers — the outer loop must be sequential so each
+            # unused center picks the current `argmax(costs)` after previous
+            # reassignments have updated `costs`. The inner loop is independent
+            # across `s` and may be threaded.
+            for c in unused
                 avgs[c] = deepcopy(sequences[argmax(costs)])
                 @optional_threaded threaded for s = 1:nseq
                     seq = sequences[s]


### PR DESCRIPTION
## Summary
- The unused-cluster-center reinitialization in `dbaclust_single` ran the outer `for c in unused` with `@optional_threaded`. The algorithm needs that loop sequential: each iteration picks `sequences[argmax(costs)]` and then updates `costs` so the next iteration picks a different sequence. With threading, multiple unused centers see the same `argmax(costs)` and collapse onto the same sequence, plus concurrent writes to `costs[s]` are a data race.
- Kept the inner per-sequence loop threadable — writes are per-`s` and safe.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] Run `dbaclust(..., threaded=true)` on a small dataset where unused centers occur; confirm distinct centers land on distinct sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)