### PR TITLE
Guard convergence ratio against zero cost in dba/dbaclust

### DIFF
--- a/src/dba.jl
+++ b/src/dba.jl
@@ -75,7 +75,7 @@ function dba(
         store_trace && push!(cost_trace, newcost)
 
         # check convergence
-        Δ = (cost - newcost) / newcost
+        Δ = newcost > 0 ? (cost - newcost) / newcost : zero(newcost)
         if Δ < rtol
             converged = true
         else

--- a/src/dbaclust.jl
+++ b/src/dbaclust.jl
@@ -285,7 +285,7 @@ function dbaclust_single(
         store_trace && push!(cost_trace, total_cost)
 
         # check convergence
-        Δ = (last_cost - total_cost) / total_cost
+        Δ = total_cost > 0 ? (last_cost - total_cost) / total_cost : zero(total_cost)
         if Δ < rtol
             converged = true
         else


### PR DESCRIPTION
## Summary
- When DBA / dbaclust cost reached `0` (e.g. identical sequences or a perfect fit), the convergence check `Δ = (prev - cur) / cur` divided by zero, yielding `Inf` or `NaN`. `Δ < rtol` could then never be true and the loop ran to its hard iteration limit.
- Treat zero cost as already converged.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] Run `dba` on a list of identical sequences and assert convergence in ≤ 2 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)