### PR TITLE
Reject M ≤ 1 in prepare_gdtw

### DIFF
--- a/src/gdtw.jl
+++ b/src/gdtw.jl
@@ -184,6 +184,7 @@ function prepare_gdtw(
 ) where T
     N = length(t)
 
+    M > 1 || throw(ArgumentError("M must be > 1 (received M = $M); `update_τ!` would otherwise divide by zero."))
     (M > N / smax) || @warn "`M <= N / smax`; problem may be infeasible" M N smax
 
 


### PR DESCRIPTION
## Summary
- `update_τ!` divides by `M - 1`. With `M = 1` this is a division by zero, leaving NaNs in `τ` that silently propagate through the GDTW solve. Validate `M > 1` in `prepare_gdtw` and throw a clear `ArgumentError` instead.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] `gdtw(x, y; M=1)` raises `ArgumentError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)