### PR TITLE
Remove empty ucr testset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -686,11 +686,6 @@ using ForwardDiff, QuadGK
             data, labels = DynamicAxisWarping.Datasets.fakedata_gaussian()
         end
 
-        @testset "ucr" begin
-            @info "Testing ucr"
-
-        end
-
     end
 
 end


### PR DESCRIPTION
## Summary
- The `@testset "ucr"` block in `test/runtests.jl` had no body, so it passed trivially and gave a false impression that UCR datasets were exercised. The UCR download path was removed in commit f8f7a3f, so there is nothing left to cover.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)