### PR TITLE
Remove export of undefined stomp symbol

### DIFF
--- a/src/DynamicAxisWarping.jl
+++ b/src/DynamicAxisWarping.jl
@@ -46,8 +46,6 @@ export ZNormalizer,
        DiagonalZNormalizer,
        normalize
 
-export stomp
-
 include("utils.jl")
 
 include("distance_interface.jl")


### PR DESCRIPTION
## Summary
- `stomp` is not defined in this package or in the conditional `matrix_profile.jl` glue loaded by `@require MatrixProfile`. Exporting an undefined name passes module load but raises `UndefVarError` whenever a downstream user tries `using DynamicAxisWarping; stomp(...)`. Drop the export.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`
- [ ] `julia --project -e 'using DynamicAxisWarping'` — no warning about `stomp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)