### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/src/dba.jl
+++ b/src/dba.jl
@@ -15,7 +15,7 @@ end
 """
     avgseq, results = dba(sequences, dist::DTWDistance; kwargs...)
 
-Perfoms DTW Barycenter Averaging (DBA) given a collection of `sequences`
+Performs DTW Barycenter Averaging (DBA) given a collection of `sequences`
 and the current estimate of the average sequence.
 
 Example usage:
@@ -125,7 +125,7 @@ function dba_iteration!(
     counts .= 0
     newavg .= 0
 
-    # main ploop
+    # main loop
     for seq in sequences
         # time warp signal versus average
         # if one of the two is empty, use unconstrained window. If both are nonempty, but not the same length, distpath will throw error
@@ -152,7 +152,7 @@ function dba_iteration!(
 end
 
 
-# weirdly enought, this works for the dtw_dba_miniexample,  but does not work for dtw_dbaclust
+# weirdly enough, this works for the dtw_dba_miniexample,  but does not work for dtw_dbaclust
 #@generated function _sequentize{T,N}(s::AbstractArray{T,N})
 #    :( Sequence[ Sequence(@ncall($N, view, s, n-> n==$N ? i : Colon())) for i = 1:size(s,2) ] )
 #end

--- a/src/dbaclust.jl
+++ b/src/dbaclust.jl
@@ -110,7 +110,7 @@ end
 """
     avgseq, results = dbaclust_single(sequences, dist; kwargs...)
 
-Perfoms a single DTW Barycenter Averaging (DBA) given a collection of `sequences`
+Performs a single DTW Barycenter Averaging (DBA) given a collection of `sequences`
 and the current estimate of the average sequence.
 
 Example usage:
@@ -142,7 +142,7 @@ function dbaclust_single(
 )
 
     T = floattype(eltype(sequences))
-    # rename for convienence
+    # rename for convenience
     avgs   = init_centers
     N = length(avgs[1])
 
@@ -210,7 +210,7 @@ function dbaclust_single(
                 cluster_i2s_        = Array{Vector{Int64}}(undef, nclust)
 
                 Threads.@threads for c_ = 1:nclust
-                    # if one of the two is empty, use unconstrained window. If both are nonempty, but not the same lenght, distpath will throw error
+                    # if one of the two is empty, use unconstrained window. If both are nonempty, but not the same length, distpath will throw error
                     if isempty(i2min) && isempty(i2max)
                         cost, i1_, i2_ = distpath(dtwdist, avgs[c_], seq)
                     else
@@ -227,7 +227,7 @@ function dbaclust_single(
             else
                 # using single-core
                 for c_ = 1:nclust
-                    # if one of the two is empty, use unconstrained window. If both are nonempty, but not the same lenght, distpath will throw error
+                    # if one of the two is empty, use unconstrained window. If both are nonempty, but not the same length, distpath will throw error
                     if isempty(i2min) && isempty(i2max)
                         cost, i1_, i2_ = distpath(dtwdist, avgs[c_], seq)
                     else

--- a/src/dtw.jl
+++ b/src/dtw.jl
@@ -18,7 +18,7 @@ If `i2min/max` are provided, do DTW to align `seq1` and `seq2` confined to a win
 `i2max` specify (inclusive) lower and upper bounds for `seq2` for each index in
 `seq1`. Thus, `i2min` and `i2max` are required to be the same length as `seq1`.
 
-If `filternernel::AbstractMatrix` is provided, it's used to filter the cost matrix. Create a suitable kerlen using, e.g., `ImageFiltering.Kernel.gaussian(3)`. The filtering of the cost matrix makes the warping smoother, effectively penalizing small-scale warping.
+If `filterkernel::AbstractMatrix` is provided, it's used to filter the cost matrix. Create a suitable kernel using, e.g., `ImageFiltering.Kernel.gaussian(3)`. The filtering of the cost matrix makes the warping smoother, effectively penalizing small-scale warping.
 
 See also [`dtw_cost`](@ref) and [`dtwnn`](@ref).
 """

--- a/src/dtwnn.jl
+++ b/src/dtwnn.jl
@@ -145,7 +145,7 @@ end
 """
     search_result = dtwnn(q, y, dist, rad, [normalizer::Type{Nothing}]; kwargs...)
 
-Compute the nearest neighbor to `q` in `y`. An optinal normalizer type can be supplied, see, `ZNormalizer, DiagonalZNormalizer, NormNormalizer`.
+Compute the nearest neighbor to `q` in `y`. An optional normalizer type can be supplied, see, `ZNormalizer, DiagonalZNormalizer, NormNormalizer`.
 
 # Arguments:
 - `q`: query (the short time series)

--- a/src/gdtw.jl
+++ b/src/gdtw.jl
@@ -135,8 +135,8 @@ The parameters are:
 * `M`: the discretization of the values obtained by the warping path
 * `metric`:  a function `metric(u,v) -> ℝ` to compute differences between the signals at a time point (such as a Distances.jl distance)
 * `Rcum`: penalty function on the cumulative warp
-* `Rinst`: penalty function on the instantaenous warping. Should be infinite outside of `[smin, smax]`.
-* `smin`, `smax`: minimum and maximum allowed instantaenous warping. Should have `smin > 0` and `smin < smax`.
+* `Rinst`: penalty function on the instantaneous warping. Should be infinite outside of `[smin, smax]`.
+* `smin`, `smax`: minimum and maximum allowed instantaneous warping. Should have `smin > 0` and `smin < smax`.
 * `λcum`, `λinst`: the regularization constants for `Rcum` and `Rinst`, respectively
 
 The following may be pre-allocated and reused between distance computations with the same `M` and `N` (or `length(t)`).


### PR DESCRIPTION
## Summary
Consolidated typo cleanup across `src/`. No code semantics affected.

| File | Typo | Correction |
|---|---|---|
| `src/dtw.jl` | filternernel | filterkernel |
| `src/dtw.jl` | kerlen | kernel |
| `src/dba.jl` | Perfoms | Performs |
| `src/dba.jl` | # main ploop | # main loop |
| `src/dba.jl` | enought | enough |
| `src/dbaclust.jl` | Perfoms | Performs |
| `src/dbaclust.jl` | convienence | convenience |
| `src/dbaclust.jl` | lenght (×2) | length |
| `src/dtwnn.jl` | optinal | optional |
| `src/gdtw.jl` | instantaenous (×2) | instantaneous |

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.test()'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)